### PR TITLE
Add open source finance projects to markdown list

### DIFF
--- a/docs/osr-resources/open-source-finance-projects.md
+++ b/docs/osr-resources/open-source-finance-projects.md
@@ -47,3 +47,11 @@ This is a Python wrapper for [TA-LIB](http://ta-lib.org) based on Cython instead
 The original Python bindings included with TA-Lib use [SWIG](http://swig.org) which unfortunately are difficult to install and aren't as efficient as they could be. Therefore this project uses [Cython](https://cython.org) and [Numpy](https://numpy.org) to efficiently and cleanly bind to TA-Lib -- producing results 2-4 times faster than the SWIG interface.
 
 Check out TA-Lib here ... https://github.com/mrjbq7/ta-lib
+
+### Alpha Vantage
+
+Alpha Vantage delivers a free API for real time financial data and most used finance indicators in a simple json or pandas format.
+
+This module implements a python interface to the free API provided by [Alpha Vantage](https://www.alphavantage.co/). It requires a free API key, that can be requested from http://www.alphavantage.co/support/#api-key. You can have a look at all the API calls available in their [API documentation](https://www.alphavantage.co/documentation/).
+
+Check out Alpha Vantage here ... https://github.com/RomelTorres/alpha_vantage

--- a/docs/osr-resources/open-source-finance-projects.md
+++ b/docs/osr-resources/open-source-finance-projects.md
@@ -8,13 +8,11 @@ Feel free to drop us a PR and we'll mention yours too!
 
 Are you finding the sheer amount of information on the internet daunting?
 
-[Jeroen Bouma's](https://github.com/JerBouma) hugely popular Python project tries to solve that. 
+[Jeroen Bouma's](https://github.com/JerBouma) hugely popular Python project tries to solve that.
 
->  It features 300.000+ symbols containing Equities, ETFs, Funds, Indices, Currencies, Cryptocurrencies and Money Markets. It therefore allows you to obtain a broad overview of sectors, industries, types of investments and much more.
+> It features 300.000+ symbols containing Equities, ETFs, Funds, Indices, Currencies, Cryptocurrencies and Money Markets. It therefore allows you to obtain a broad overview of sectors, industries, types of investments and much more.
 
 [more here](https://github.com/JerBouma/FinanceDatabase)
-
-
 
 ## Other Lists
 

--- a/docs/osr-resources/open-source-finance-projects.md
+++ b/docs/osr-resources/open-source-finance-projects.md
@@ -23,3 +23,11 @@ Are you finding the sheer amount of information on the internet daunting?
 If you're looking for an exhaustive set of quant libraries (mainly across R and Python) then [Wilson Freitas](https://github.com/wilsonfreitas) has got you covered.
 
 [check it out](https://github.com/wilsonfreitas/awesome-quant)
+
+### Dash
+
+Dash is the most downloaded, trusted Python framework for building ML & data science web apps.
+
+Built on top of [Plotly.js](https://github.com/plotly/plotly.js), [React](https://reactjs.org/) and [Flask](https://palletsprojects.com/p/flask/), Dash ties modern UI elements like dropdowns, sliders, and graphs directly to your analytical Python code. Read our tutorial (proudly crafted ❤️ with Dash itself).
+
+Check out Dash here ... https://github.com/plotly/dash

--- a/docs/osr-resources/open-source-finance-projects.md
+++ b/docs/osr-resources/open-source-finance-projects.md
@@ -31,3 +31,19 @@ Dash is the most downloaded, trusted Python framework for building ML & data sci
 Built on top of [Plotly.js](https://github.com/plotly/plotly.js), [React](https://reactjs.org/) and [Flask](https://palletsprojects.com/p/flask/), Dash ties modern UI elements like dropdowns, sliders, and graphs directly to your analytical Python code. Read our tutorial (proudly crafted ❤️ with Dash itself).
 
 Check out Dash here ... https://github.com/plotly/dash
+
+### TA-Lib
+
+This is a Python wrapper for [TA-LIB](http://ta-lib.org) based on Cython instead of SWIG.
+
+> TA-Lib is widely used by trading software developers requiring to perform
+> technical analysis of financial market data.
+>
+> - Includes 150+ indicators such as ADX, MACD, RSI, Stochastic, Bollinger
+>   Bands, etc.
+> - Candlestick pattern recognition
+> - Open-source API for C/C++, Java, Perl, Python and 100% Managed .NET
+
+The original Python bindings included with TA-Lib use [SWIG](http://swig.org) which unfortunately are difficult to install and aren't as efficient as they could be. Therefore this project uses [Cython](https://cython.org) and [Numpy](https://numpy.org) to efficiently and cleanly bind to TA-Lib -- producing results 2-4 times faster than the SWIG interface.
+
+Check out TA-Lib here ... https://github.com/mrjbq7/ta-lib


### PR DESCRIPTION
## Description

The following open source in finance projects have been added to `docs/osr-resources/open-source-finance-projects.md` for community reference.

- [Dash](https://github.com/plotly/dash)
  - https://github.com/plotly/dash 
  - Maintained by  @ashmpace, @bpostlethwaite, @BRONSOLO, @chriddyp, @cldougl, @kMutagene, @ndrezn, @nicolaskruchten, @toxicbeans
- [TA-Lib](https://github.com/mrjbq7/ta-lib)
  - https://github.com/mrjbq7/ta-lib 
  - Maintained by @mrjbq7
- [Alpha Vantage](https://github.com/RomelTorres/alpha_vantage)
  - https://github.com/RomelTorres/alpha_vantage 
  - Maintained by @RomelTorres